### PR TITLE
Tell nginx about application/wasm MIME-type

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -9,3 +9,5 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 
 FROM nginx as final
 COPY --from=builder /usr/src/app/static /usr/share/nginx/html
+COPY nginx-wasm-mime-type.conf /etc/nginx/conf.d/nginx-wasm-mime-type.conf
+EXPOSE 80

--- a/app/nginx-wasm-mime-type.conf
+++ b/app/nginx-wasm-mime-type.conf
@@ -1,0 +1,3 @@
+types {
+	application/wasm wasm;
+}


### PR DESCRIPTION
Fixes the MIME type for .wasm files, which removes a console warning
regarding performance of loading wasm