### PR TITLE
Add `ProjectTasks` to core-lib

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -51,7 +51,7 @@ dependencies = [
 
 [[package]]
 name = "taskboard-core-lib"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "serde",
 ]

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -51,7 +51,7 @@ dependencies = [
 
 [[package]]
 name = "taskboard-core-lib"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "serde",
 ]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskboard-core-lib"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Christian Fosli <cfosli@gmail.com>"]
 edition = "2018"
 description = "Core library for taskboard web application"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -12,6 +12,15 @@ pub struct Task {
     pub remaining_work: Option<u8>,
 }
 
+/// A wrapper type with a list of tasks associated to a project
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ProjectTasks {
+    /// Id of the project
+    pub project_id: String,
+    /// All tasks associated with the project
+    pub tasks: Vec<Task>,
+}
+
 impl Task {
     /// Creates a new Task with status Todo
     pub fn new(title: &str) -> Task {


### PR DESCRIPTION
Because it seems `serde` has problems deserializing to a `Vec`