### PR TITLE
Ask letsencrypt for ECDSA TLS cert

### DIFF
--- a/infra/k8s/terraform/acme-issuer.yaml
+++ b/infra/k8s/terraform/acme-issuer.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt
+spec:
+  acme:
+    email: cfosli@gmail.com
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: letsencrypt
+    solvers:
+    - http01:
+        ingress:
+          class: nginx

--- a/infra/k8s/terraform/cert_manager.tf
+++ b/infra/k8s/terraform/cert_manager.tf
@@ -19,21 +19,11 @@ resource "helm_release" "certManager" {
 }
 
 resource "kubectl_manifest" "tlsCertIssuer" {
-  yaml_body  = <<YAML
-apiVersion: cert-manager.io/v1
-kind: ClusterIssuer
-metadata:
-  name: letsencrypt
-spec:
-  acme:
-    email: cfosli@gmail.com
-    server: https://acme-v02.api.letsencrypt.org/directory
-    privateKeySecretRef:
-      name: letsencrypt
-    solvers:
-    - http01:
-        ingress:
-          class: nginx
-YAML
+  yaml_body  = file("acme-issuer.yaml")
+  depends_on = [helm_release.certManager]
+}
+
+resource "kubectl_manifest" "tlsCert" {
+  yaml_body  = file("tls-cert.yaml")
   depends_on = [helm_release.certManager]
 }

--- a/infra/k8s/terraform/ingress.yaml
+++ b/infra/k8s/terraform/ingress.yaml
@@ -4,13 +4,12 @@ metadata:
   name: taskboard-ingress
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /$2
-    cert-manager.io/cluster-issuer: letsencrypt
 spec:
   ingressClassName: nginx
   tls:
   - hosts:
     - taskboard.cloud
-    secretName: tls-secret
+    secretName: tls-cert
   rules:
   - host: taskboard.cloud
     http:

--- a/infra/k8s/terraform/tls-cert.yaml
+++ b/infra/k8s/terraform/tls-cert.yaml
@@ -1,0 +1,13 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: tls-cert
+spec:
+  secretName: tls-cert
+  privateKey:
+    algorithm: ecdsa
+  dnsNames:
+  - taskboard.cloud
+  issuerRef:
+    name: letsencrypt
+    kind: ClusterIssuer

--- a/infra/k8s/terraform/tls-cert.yaml
+++ b/infra/k8s/terraform/tls-cert.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   secretName: tls-cert
   privateKey:
-    algorithm: ecdsa
+    algorithm: ECDSA
   dnsNames:
   - taskboard.cloud
   issuerRef:


### PR DESCRIPTION
Replace the cert-manager annotation on ingress with a `Certificate` resource,
so that we can specify which algorithm to use.

Use ECDSA rather than RSA keypair.